### PR TITLE
Fix issues when pulling over 100 investigations

### DIFF
--- a/InsightIDR4Py.py
+++ b/InsightIDR4Py.py
@@ -223,6 +223,8 @@ class InsightIDR(object):
         }
         # filter the parameters to be only those with a supplied value
         params = {key:val for key, val in params.items() if val}
+        if 'index' not in params:
+            params["index"] = 0
         # get the initial set of investigations
         url = self.investigations_url
         self.session.headers["Accept-version"] = "investigations-preview"
@@ -234,8 +236,8 @@ class InsightIDR(object):
         investigations.extend(result["data"])
         # iterate through remaining investigations and add them to the output list
         while len(investigations) < total:
-            params["index"] += 100
-            response = self.session.get(url, params)
+            params["index"] += 1
+            response = self.session.get(url, params=params)
             result = response.json()
             investigations.extend(result["data"])
 


### PR DESCRIPTION
When calling "ListInvestigations" and receiving over 100 results (multiple pages) numerous errors occur:

- params' "index" key does not exist due to the functionality on line 225 seeing 0 as `val` not existing, therefore not setting the index key on the final object
- After adding the 'index' key, there's an error stating that Session.get() specifies two parameters, but we're sending three. This is resolved by adding `params=` in front of the params variable in the call
- "data" key not present in the results, this is because the index is incremented by 100, however the index should be seen as a page number, not a number of results to skip. So currently the code is going from page 0 to page 100, at 100 results per page. This is simply resolved by incrementing by 1 instead of by 100

Please implement this promptly as I would like to use this library but this is breaking everything and I can only do so much modifying my local files.

Thanks!